### PR TITLE
enhancement: schedule a job with payload

### DIFF
--- a/scrapy_do/client/commands.py
+++ b/scrapy_do/client/commands.py
@@ -212,6 +212,8 @@ def schedule_job_arg_setup(subparsers):
                         help='spider name')
     parser.add_argument('--when', type=str, default='now',
                         help='scheduling spec')
+    parser.add_argument('--payload', type=str, default='{}',
+                        help='the args for spiders')
 
 
 def schedule_job_arg_process(args):
@@ -225,7 +227,8 @@ def schedule_job_arg_process(args):
     return {
         'project': args.project,
         'spider': args.spider,
-        'when': args.when
+        'when': args.when,
+        'payload': args.payload
     }
 
 

--- a/scrapy_do/webservice.py
+++ b/scrapy_do/webservice.py
@@ -259,12 +259,13 @@ class ScheduleJob(JsonResource):
 
     #---------------------------------------------------------------------------
     def render_POST(self, request):
-        arg_require_all(request.args, [b'project', b'spider', b'when'])
+        arg_require_all(request.args, [b'project', b'spider', b'when', b'payload'])
         project = request.args[b'project'][0].decode('utf-8')
         spider = request.args[b'spider'][0].decode('utf-8')
         when = request.args[b'when'][0].decode('utf-8')
+        payload = request.args[b'payload'][0].decode('utf-8')
 
-        job_id = self.parent.controller.schedule_job(project, spider, when)
+        job_id = self.parent.controller.schedule_job(project, spider, when, payload=payload)
         return {'identifier': job_id}
 
 

--- a/scrapy_do/websocket.py
+++ b/scrapy_do/websocket.py
@@ -415,7 +415,7 @@ class WSProtocol(WebSocketServerProtocol):
         Execute a job scheduling request.
         """
 
-        for field in ['project', 'spider', 'schedule']:
+        for field in ['project', 'spider', 'schedule', 'payload']:
             if field not in data:
                 msg = '{} not specified.'.format(field.title())
                 self.send_error_response(data['id'], msg)
@@ -424,7 +424,8 @@ class WSProtocol(WebSocketServerProtocol):
         try:
             jobId = self.controller.schedule_job(data['project'],
                                                  data['spider'],
-                                                 data['schedule'])
+                                                 data['schedule'],
+                                                 payload=data['payload'])
             msg = {
                 'jobId': jobId
             }

--- a/ui/src/components/JobListItem.js
+++ b/ui/src/components/JobListItem.js
@@ -150,6 +150,9 @@ class JobListItem extends Component {
           {secondaryPanel}
           Scheduled by {capitalizeFirst(job.actor)} to run {job.schedule}.
         </div>
+        <div className='list-item-secondary'>
+          Payload: {job.payload}
+        </div>
       </ListGroupItem>
     );
   }

--- a/ui/src/components/ScheduleDialog.js
+++ b/ui/src/components/ScheduleDialog.js
@@ -26,7 +26,8 @@ const defaultState = {
   submitDisabled: true,
   project: '__select',
   spider: '__select',
-  schedule: 'now'
+  schedule: 'now',
+  payload: '{}'
 };
 
 //------------------------------------------------------------------------------
@@ -84,7 +85,7 @@ class ScheduleDialog extends Component {
   // Schedule the job
   //----------------------------------------------------------------------------
   schedule = () => {
-    jobSchedule(this.state.project, this.state.spider, this.state.schedule)
+    jobSchedule(this.state.project, this.state.spider, this.state.schedule, this.state.payload)
       .catch(error => {
         setTimeout(() => this.dialog.showAlert(error.message), 250);
       });
@@ -134,6 +135,16 @@ class ScheduleDialog extends Component {
     this.setState({
       schedule: event.target.value,
       submitDisabled: !scheduleValid(event.target.value)
+    });
+  };
+
+  //----------------------------------------------------------------------------
+  // On payload change
+  //----------------------------------------------------------------------------
+  onPayloadChange = (event) => {
+    this.setState({
+      payload: event.target.value,
+      submitDisabled: !1
     });
   };
 
@@ -211,6 +222,20 @@ class ScheduleDialog extends Component {
     );
 
     //--------------------------------------------------------------------------
+    // Payload input
+    //--------------------------------------------------------------------------
+    const payloadInput = (
+      <FormGroup
+        controlId='payloadInput'
+      >
+        <ControlLabel>Payload</ControlLabel>
+        <FormControl type='text' disabled={this.state.scheduleDisabled}
+                     value={this.state.payload}
+                     onChange={this.onPayloadChange} />
+      </FormGroup>
+    );
+
+    //--------------------------------------------------------------------------
     // The whole thing
     //--------------------------------------------------------------------------
     return (
@@ -221,6 +246,7 @@ class ScheduleDialog extends Component {
             {projectSelector}
             {spiderSelector}
             {scheduleInput}
+            {payloadInput}
           </Modal.Body>
           <Modal.Footer>
             <Button

--- a/ui/src/utils/backendActions.js
+++ b/ui/src/utils/backendActions.js
@@ -40,11 +40,12 @@ export function jobCancel(jobId) {
 //------------------------------------------------------------------------------
 // Schedule job
 //------------------------------------------------------------------------------
-export function jobSchedule(project, spider, schedule) {
+export function jobSchedule(project, spider, schedule, payload) {
   return backend.sendMessage({
     action: 'JOB_SCHEDULE',
     project,
     spider,
-    schedule
+    schedule,
+    payload
   });
 }


### PR DESCRIPTION
@ljanyst ,   Great appreciate for your project.  make my life easier.  I use it to schedule my scrapy spider to collect target data.  

However,  my scrapy spider need some arguments, the scrapy can support it,  and scrapy-do don't support this.
e.g. on command line, I can invoke my spider by `$ scrapy crawl my_spider -a loop=3 -a target_link=www.myweb.com`    but on scrapy-do,  there is no way for me to input the arguments.

So I make an enhancement for this.  Hope it could be useful for others have the same requirement. 

Below are some pics:
![image](https://user-images.githubusercontent.com/20814036/69939881-ba823700-1495-11ea-942e-e33d5dfa6972.png)
![image](https://user-images.githubusercontent.com/20814036/69939910-cb32ad00-1495-11ea-97c3-dff7bd5485d0.png)
