### PR TITLE
[Feature] Adding output parameter option to schedule tool

### DIFF
--- a/scrapy_do/client/commands.py
+++ b/scrapy_do/client/commands.py
@@ -124,7 +124,8 @@ def list_jobs_arg_process(args):
 def list_jobs_rsp_parse(rsp):
     data = []
     headers = ['identifier', 'project', 'spider', 'status', 'schedule',
-               'description', 'actor', 'timestamp', 'duration', 'payload']
+               'description', 'actor', 'timestamp', 'duration', 'payload',
+               'output']
 
     for job in rsp['jobs']:
         datum = []
@@ -228,6 +229,8 @@ def schedule_job_arg_setup(subparsers):
                         help='description of the job')
     parser.add_argument('--payload', type=str, default='{}',
                         help='payload')
+    parser.add_argument('--output', type=str, default=None,
+                        help='output file for scrapy')
 
 
 def schedule_job_arg_process(args):
@@ -251,7 +254,8 @@ def schedule_job_arg_process(args):
         'spider': args.spider,
         'when': args.when,
         'description': args.description,
-        'payload': payload
+        'payload': payload,
+        'output': args.output
     }
 
 

--- a/scrapy_do/webservice.py
+++ b/scrapy_do/webservice.py
@@ -272,9 +272,14 @@ class ScheduleJob(JsonResource):
         if b'payload' in request.args:
             payload = request.args[b'payload'][0].decode('utf-8')
 
+        output = None
+        if b'output' in request.args:
+            output = request.args[b'output'][0].decode('utf-8')
+
         job_id = self.parent.controller.schedule_job(project, spider, when,
                                                      description=description,
-                                                     payload=payload)
+                                                     payload=payload,
+                                                     output=output)
         return {'identifier': job_id}
 
 

--- a/scrapy_do/websocket.py
+++ b/scrapy_do/websocket.py
@@ -429,12 +429,15 @@ class WSProtocol(WebSocketServerProtocol):
         if 'payload' in data:
             payload = data['payload']
 
+        output = data.get('output', None)
+
         try:
             jobId = self.controller.schedule_job(data['project'],
                                                  data['spider'],
                                                  data['schedule'],
                                                  description=description,
-                                                 payload=payload)
+                                                 payload=payload,
+                                                 output=output)
             msg = {
                 'jobId': jobId
             }

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -330,16 +330,18 @@ class ClientTests(unittest.TestCase):
             'timestamp': 'foo',
             'duration': 'foo',
             'description': 'foo',
-            'payload': '{}'
+            'payload': '{}',
+            'output': '/foo/bar'
         }]}
         ret = cmd.list_jobs_rsp_parse(rsp)
-        self.assertIn(['foo'] * 9 + ['{}'], ret['data'])
+        self.assertIn(['foo'] * 9 + ['{}'] + ['/foo/bar'], ret['data'])
 
         rsp['jobs'][0]['payload'] = 'foo'
         with patch('builtins.print'):
             ret = cmd.list_jobs_rsp_parse(rsp)
-        self.assertIn(['foo'] * 9 + ['{"error": "malformed payload"}'],
-                      ret['data'])
+        self.assertIn(
+            ['foo'] * 9 + ['{"error": "malformed payload"}'] + ['/foo/bar'],
+            ret['data'])
 
         #-----------------------------------------------------------------------
         # Push project

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -75,7 +75,7 @@ class ScheduleTests(unittest.TestCase):
         for job in jobs:
             self.assertEqual(job.description, '')
 
-        self.assertEqual(int(self.schedule.get_metadata('version')), 2)
+        self.assertEqual(int(self.schedule.get_metadata('version')), 3)
 
         lst = glob.glob(db_file_test + '.bak*')
         self.assertEqual(len(lst), 1)
@@ -146,6 +146,6 @@ class ScheduleTests(unittest.TestCase):
 
     #---------------------------------------------------------------------------
     def test_metadata(self):
-        self.assertEqual(int(self.schedule.get_metadata('version')), 2)
+        self.assertEqual(int(self.schedule.get_metadata('version')), 3)
         with self.assertRaises(KeyError):
             self.schedule.get_metadata('foo')


### PR DESCRIPTION
This PR adds the capability to specify an output directory to scrapy crawlers when scheduling a job using its `-o` parameter (see example in this [video tutorial](https://www.youtube.com/watch?v=kkWhQKtxT2I)).
It is particularly useful to schedule a job and quickly log to a CSV or a JSON, using `scrapy`'s way of generating file outputs instead of needing custom implementations.

Usage:
```
scrapy-do-cl schedule-job --project <project> --spider <spider> --when <interval> --output <output_path>
```

PS: @ljanyst Thanks for making this project open source, I found it pretty cool and useful! I hope you find this PR useful as well. I'll be looking forward to your comments!