### PR TITLE
fix: request.path bytes error

### DIFF
--- a/scrapy_do/webservice.py
+++ b/scrapy_do/webservice.py
@@ -353,7 +353,12 @@ class GetLogFile(resource.Resource):
             request.setHeader('Content-Type', 'text/plain')
             request.setHeader('Access-Control-Allow-Origin', '*')
             controller = self.parent.parent.controller
-            filename = os.path.basename(urllib.parse.unquote(request.path))
+            
+            req_path = request.path
+            if isinstance(req_path, bytes):
+                req_path = req_path.decode('utf-8')
+
+            filename = os.path.basename(urllib.parse.unquote(req_path))
             filepath = os.path.join(controller.log_dir, filename)
             job_id = os.path.splitext(filename)[0]
 


### PR DESCRIPTION
fix error of following message:

```
          File "/code/.venv/lib/python3.8/site-packages/scrapy_do/webservice.py", line 356, in do_async
            filename = os.path.basename(urllib.parse.unquote(request.path))
          File "/usr/local/lib/python3.8/urllib/parse.py", line 635, in unquote
            raise TypeError('Expected str, got bytes')
        builtins.TypeError: Expected str, got bytes
```

------
Python 3.8.9

Twisted==21.2.0
urllib3==1.26.5
Scrapy==2.5.0
scrapy-do==0.5.0
